### PR TITLE
fix: compile error waitpid() not found

### DIFF
--- a/src/flutter_pty_unix.c
+++ b/src/flutter_pty_unix.c
@@ -7,6 +7,7 @@
 #include <unistd.h>
 #include <termios.h>
 #include <sys/ioctl.h>
+#include <sys/wait.h>
 
 #include "forkpty.h"
 #include "flutter_pty.h"


### PR DESCRIPTION
On my NixOS system I have to explicitly include `sys/wait.h` to sucessfully compile the library.
